### PR TITLE
Enhance: Remove redundant parent_name and parent_type on frontend/backend

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     haproxy = {
       source = "cepitacio/haproxy"
-      version = "0.0.7"
+      version = "0.0.2"
     }
   }
 }

--- a/docs/resources/backend.md
+++ b/docs/resources/backend.md
@@ -23,19 +23,13 @@ resource "haproxy_backend" "backend" {
     algorithm = "round-robin"
   }
 
-  dynamic "httpchk_params" {
-    content {
-      method = "GET"
-      uri    = "/health"
-    }
+  httpchk_params {
+    method = "GET"
+    uri    = "/health"
   }
 
-  dynamic "httpcheck" {
-    content {
-      parent_name = "backend_test"
-      parent_type = "backend"
-      index       = 1
-    }
+  httpcheck {
+    index       = 0
   }
 }
 ```

--- a/docs/resources/frontend.md
+++ b/docs/resources/frontend.md
@@ -19,40 +19,26 @@ resource "haproxy_frontend" "frontend" {
   mode            = "http"
   monitor_uri     = "/fe-status-check"
 
-  dynamic "monitor_fail" {
-    content {
-      cond        = "if"
-      cond_test   = "nbsrv(frontend_test)"
-    }
+  monitor_fail {
+    cond        = "if"
+    cond_test   = "nbsrv(frontend_test)"
   }
 
-  dynamic "acl" {
-    content {
-      acl_name    = "acl_test"
-      index       = 1
-      parent_name = "frontend_test"
-      parent_type = "frontend"
-      criterion   = "hdr(host)"
-      value       = "example.com"
-    }
+  acl {
+    acl_name    = "acl_test"
+    index       = 0
+    criterion   = "hdr(host)"
+    value       = "example.com"
   }
 
-  dynamic "httprequestrule" {
-    content {
-      index       = 1
+  httprequestrule {
+      index       = 0
       type        = "allow"
-      parent_name = "frontend_test"
-      parent_type = "frontend"
-    }
   }
 
-  dynamic "httpresponserule" {
-    content {
-      index       = 1
-      type        = "set-header"
-      parent_name = "frontend_test"
-      parent_type = "frontend"
-    }
+  httpresponserule {
+    index       = 0
+    type        = "set-header"
   }
 
   depends_on = [

--- a/docs/resources/server.md
+++ b/docs/resources/server.md
@@ -18,23 +18,7 @@ resource "haproxy_server" "server" {
   address            = "192.168.1.10"
   port               = 8080
   parent_name        = "example-backend"
-  check              = "enabled"
-  check_ssl          = "enabled"
   parent_type        = "backend"
-  health_check_port  = 8081
-  fall               = 3
-  rise               = 2
-  inter              = 5000
-  ssl                = "enabled"
-  verify             = "none"
-  ssl_certificate    = "/etc/haproxy/certs/example-server.pem"
-  ssl_cafile         = "/etc/haproxy/ca.crt"
-  ciphersuites       = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
-  force_sslv3        = "disabled"
-  force_tlsv10       = "disabled"
-  force_tlsv11       = "enabled"
-  force_tlsv12       = "enabled"
-  force_tlsv13       = "enabled"
 
   depends_on         = [
     haproxy_backend.backend

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     haproxy = {
       source  = "cepitacio/haproxy"
-      version = "0.0.7"
+      version = "0.0.1"
     }
   }
 }

--- a/examples/resources/haproxy_backend/resource.tf
+++ b/examples/resources/haproxy_backend/resource.tf
@@ -8,18 +8,12 @@ resource "haproxy_backend" "backend" {
     algorithm = "round-robin"
   }
 
-  dynamic "httpchk_params" {
-    content {
-      method = "GET"
-      uri    = "/health"
-    }
+  httpchk_params {
+    method = "GET"
+    uri    = "/health"
   }
 
-  dynamic "httpcheck" {
-    content {
-      parent_name = "backend_test"
-      parent_type = "backend"
-      index       = 1
-    }
+  httpcheck {
+    index       = 1
   }
 }

--- a/examples/resources/haproxy_bind/resource.tf
+++ b/examples/resources/haproxy_bind/resource.tf
@@ -2,8 +2,6 @@ resource "haproxy_bind" "bind" {
   name            = "bind_test"
   port            = 80
   address         = "192.168.1.5"
-  parent_name     = "frontend_test"
-  parent_type     = "frontend"
 
   depends_on         = [
     haproxy_frontend.front_end

--- a/examples/resources/haproxy_frontend/resource.tf
+++ b/examples/resources/haproxy_frontend/resource.tf
@@ -4,40 +4,26 @@ resource "haproxy_frontend" "frontend" {
   mode            = "http"
   monitor_uri     = "/fe-status-check"
 
-  dynamic "monitor_fail" {
-    content {
+  monitor_fail {
       cond        = "if"
       cond_test   = "nbsrv(frontend_test)"
-    }
   }
 
-  dynamic "acl" {
-    content {
-      acl_name    = "acl_test"
-      index       = 1
-      parent_name = "frontend_test"
-      parent_type = "frontend"
-      criterion   = "hdr(host)"
-      value       = "example.com"
-    }
+  acl {
+    acl_name    = "acl_test"
+    index       = 1
+    criterion   = "hdr(host)"
+    value       = "example.com"
   }
 
-  dynamic "httprequestrule" {
-    content {
-      index       = 1
-      type        = "allow"
-      parent_name = "frontend_test"
-      parent_type = "frontend"
-    }
+  httprequestrule {
+    index       = 1
+    type        = "allow"
   }
 
-  dynamic "httpresponserule" {
-    content {
-      index       = 1
-      type        = "set-header"
-      parent_name = "frontend_test"
-      parent_type = "frontend"
-    }
+  httpresponserule {
+    index       = 1
+    type        = "set-header"
   }
 
   depends_on = [

--- a/examples/resources/haproxy_server/resource.tf
+++ b/examples/resources/haproxy_server/resource.tf
@@ -3,23 +3,8 @@ resource "haproxy_server" "server" {
   address            = "192.168.1.10"
   port               = 8080
   parent_name        = "example-backend"
-  check              = "enabled"
-  check_ssl          = "enabled"
   parent_type        = "backend"
-  health_check_port  = 8081
-  fall               = 3
-  rise               = 2
-  inter              = 5000
-  ssl                = "enabled"
-  verify             = "none"
-  ssl_certificate    = "/etc/haproxy/certs/example-server.pem"
-  ssl_cafile         = "/etc/haproxy/ca.crt"
-  ciphersuites       = "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256"
-  force_sslv3        = "disabled"
-  force_tlsv10       = "disabled"
-  force_tlsv11       = "enabled"
-  force_tlsv12       = "enabled"
-  force_tlsv13       = "enabled"
+
 
   depends_on         = [
     haproxy_backend.backend

--- a/internal/backend/payload.go
+++ b/internal/backend/payload.go
@@ -32,7 +32,6 @@ type BackendPayload struct {
 	Balance            Balance       `json:"balance"`
 	HttpchkParams      HttpchkParams `json:"httpchk_params"`
 	Forwardfor         ForwardFor    `json:"forwardfor"`
-	HttpCheck          HttpCheck     `json:"http-check"`
 }
 
 type Balance struct {
@@ -50,16 +49,6 @@ type HttpchkParams struct {
 
 type ForwardFor struct {
 	Enabled string `json:"enabled"`
-}
-
-type HttpCheck struct {
-	Index   int    `json:"index"`
-	Match   string `json:"match"`
-	Pattern string `json:"pattern"`
-	Type    string `json:"type"`
-	Address string `json:"address"`
-	Port    *int   `json:"port,omitempty"`
-	Method  string `json:"method"`
 }
 
 type Manager struct {

--- a/internal/common_services/acl/payload.go
+++ b/internal/common_services/acl/payload.go
@@ -14,10 +14,8 @@ type AclWrapper struct {
 }
 
 type AclPayload struct {
-	AclName    string `json:"acl_name"`
-	Criterion  string `json:"criterion"`
-	Index      int    `json:"index"`
-	Value      string `json:"value"`
-	ParentName string `json:"parent_name"`
-	ParentType string `json:"parent_type"`
+	AclName   string `json:"acl_name"`
+	Criterion string `json:"criterion"`
+	Index     int    `json:"index"`
+	Value     string `json:"value"`
 }

--- a/internal/common_services/httpcheck/payload.go
+++ b/internal/common_services/httpcheck/payload.go
@@ -18,7 +18,7 @@ type HttpCheckPayload struct {
 	Match   string `json:"match"`
 	Pattern string `json:"pattern"`
 	Type    string `json:"type"`
-	Address string `json:"address"`
+	Addr    string `json:"addr"`
 	Port    *int   `json:"port,omitempty"`
 	Method  string `json:"method"`
 }

--- a/internal/common_services/httprequestrule/payload.go
+++ b/internal/common_services/httprequestrule/payload.go
@@ -45,6 +45,4 @@ type HttpRequestRulePayload struct {
 	WaitTime    int    `json:"wait_time"`
 	RedirType   string `json:"redir_type"`
 	RedirValue  string `json:"redir_value"`
-	ParentName  string `json:"parent_name"`
-	ParentType  string `json:"parent_type"`
 }

--- a/internal/common_services/httpresponserule/payload.go
+++ b/internal/common_services/httpresponserule/payload.go
@@ -45,6 +45,4 @@ type HttpResponseRulePayload struct {
 	WaitTime    int    `json:"wait_time"`
 	RedirType   string `json:"redir_type"`
 	RedirValue  string `json:"redir_value"`
-	ParentName  string `json:"parent_name"`
-	ParentType  string `json:"parent_type"`
 }

--- a/internal/utils/get_sort_items.go
+++ b/internal/utils/get_sort_items.go
@@ -36,7 +36,7 @@ func FetchAndSortSchemaItemsByIndex(getFunc func(key string) interface{}, key st
 		return indexI < indexJ
 	})
 	jsonData1, err := json.MarshalIndent(items, "", "  ")
-	fmt.Println(string(jsonData1), err)
+	fmt.Println("Sorted schema items by index", string(jsonData1), err)
 	return items, nil
 }
 func FetchAndSortSchemaItemsByIndexList(getFunc func(key string) interface{}, key string) ([]map[string]interface{}, error) {


### PR DESCRIPTION
- Simplified code by removing `parent_name` and `parent_type` fields.
- Refactored logic to streamline usage across frontend and backend configurations.
- Updated examples and documentation to align with the changes.
- Improved code maintainability by reducing redundancy.